### PR TITLE
[fix] Mathematically correct rounding to cents.

### DIFF
--- a/lib/polish_number.rb
+++ b/lib/polish_number.rb
@@ -4,10 +4,10 @@ require "polish_number/process"
 
 module PolishNumber
   def self.in_words(number)
-    Process.in_words(number)
+    Process.in_words(number.round(2))
   end
 
   def self.with_currency(number)
-    Process.with_currency(number)
+    Process.with_currency(number.round(2))
   end
 end

--- a/spec/polish_number_spec.rb
+++ b/spec/polish_number_spec.rb
@@ -51,6 +51,8 @@ describe :PolishNumber do
     '100.23' => 'sto złotych dwadzieścia trzy grosze',
     '1234.324' => 'jeden tysiąc dwieście trzydzieści cztery złote trzydzieści' \
                   ' dwa grosze',
+    '1234.326' => 'jeden tysiąc dwieście trzydzieści cztery złote trzydzieści' \
+                  ' trzy grosze',
   }.each do |number, translation|
     it "translates #{number} to #{translation}" do
       PolishNumber.in_words(number).should == translation


### PR DESCRIPTION
Right now both `in_words` and `with_currency` when rounding to cents cuts the end instead of rounding mathematically